### PR TITLE
Enable Using SDK instead of EDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ The below app example is assuming you're definig your schema as edn as a resourc
 - [Aleph w/ Lacinia Engine, GraphiQL](./examples/aleph/)
 - [Ring Jetty w/ Lacinia Engine, GraphiQL](./examples/ring-jetty)
 - [Service/Easy API](./examples/easy)
+- [Service/Easy API Using GraphQL Schema SDL](./examples/easy-sdl)
 - **TODO** Fullstack using the two above w/ Apollo Client
 - **TODO** TodoMVC
 - **TODO** Chat app

--- a/examples/common/resources/graphql/schema/star-wars.edn
+++ b/examples/common/resources/graphql/schema/star-wars.edn
@@ -46,7 +46,7 @@
       :functions {:type (list :DroidFunction)}
       :appearsIn {:type (non-null (list :Episode))}}}
     :addHuman
-    {:type :Droid
+    {:type :Human
      :args
      {:name      {:type (non-null String)}
       :appearsIn {:type (non-null (list :Episode))}}}}}

--- a/examples/common/resources/graphql/schema/star-wars.graphql
+++ b/examples/common/resources/graphql/schema/star-wars.graphql
@@ -1,0 +1,70 @@
+scalar UUID
+
+enum DroidFunction {
+  ASTRO
+  MEDICAL
+  PROTOCOL
+  UNKNOWN
+}
+
+enum Episode {
+  NEWHOPE
+  EMPIRE
+  JEDI
+}
+
+enum EventKind {
+  ENTITY_ADDED
+  LOG
+}
+
+# --
+
+union Hero = Droid | Human
+union EventData = Droid | Human | Log
+
+# --
+
+type Droid {
+  id: UUID
+  name: String
+  functions: DroidFunction
+  appearsIn: [Episode]
+}
+
+type Event {
+  kind: EventKind
+  data: EventData
+}
+
+type Human {
+  id: UUID
+  name: String
+  appearsIn: [Episode]
+}
+
+type Log {
+  code: Int
+  message: String
+}
+
+# --
+
+type Mutation {
+  addDroid(name: String, functions: [DroidFunction], appearsIn: [Episode]!): Droid
+  addHuman(name: String, appearsIn: [Episode]!): Human
+}
+
+type Query {
+  droid(id: UUID!): Droid
+  droids(episode: Episode): [Droid]
+  hero(id: UUID): Hero
+  heros(episode: Episode): [Hero]
+  human(id: UUID): Human
+  humans(episode: Episode): [Human]
+}
+
+type Subscription {
+  events: Event
+}
+

--- a/examples/easy-sdl/README.md
+++ b/examples/easy-sdl/README.md
@@ -1,0 +1,19 @@
+##  Prebuilt Service Example
+
+This example provides an easy interface which can be used for a new GraphQL application.
+
+What is shown in `server.core` is representative of what most new GraphQL
+applications may need. 
+
+To run the server:
+```shell
+# In Shell 0
+$ clj -M -m server.core
+```
+
+To open GraphiQL, open your preferred browser and navigate to
+`http://localhost:9113/graphiql`, or via shell:
+```shell
+$ open http://localhost:9113/graphiql
+```
+

--- a/examples/easy-sdl/deps.edn
+++ b/examples/easy-sdl/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src"]
+ :deps
+ {aleph/aleph {:mvn/version "0.6.4"}
+  example/common {:local/root "../common"}
+  com.walmartlabs/lacinia {:mvn/version "1.2.1"}
+  land.bnert/graphql.kit {:local/root "../../"}}}
+

--- a/examples/easy-sdl/src/server/core.clj
+++ b/examples/easy-sdl/src/server/core.clj
@@ -1,0 +1,71 @@
+(ns server.core
+  (:require
+    [examples.common.lacinia-engine.star-wars.resolvers :as ex.resolvers]
+    [examples.common.core :as ex.core]
+    [graphql.kit :as kit]
+    [manifold.executor :as m.e]
+    [taoensso.timbre :refer [info]]))
+
+(def port 9113)
+
+; TODO: Figure out better examples (i.e. auth(n,z), query complexity, db, CORS)
+(defn logger [message]
+  (fn [handler]
+    (fn
+      ([req]
+       (info message "I'm a logger, fear my axe...")
+       (handler req))
+      ([req res raise]
+       (info message "I'm a logger, fear my axe at some point in the future...")
+       (handler req res raise)))))
+
+(defn health-check [endpoint]
+  (let [health? #(and (= :get (:request-method %))
+                      (= endpoint (:uri %)))
+        ok-resp {:status  200
+                 :headers {"content-type" "text/plain"}
+                 :body    "ok"}]
+    (fn [handler]
+      (fn
+        ([req]
+         (info "health sync")
+         (if (health? req)
+           ok-resp
+           (handler req)))
+        ([req res raise]
+         (info "health async")
+         (if (health? req)
+           (res ok-resp)
+           (handler req res raise)))))))
+
+(defn -main [& _args]
+  (kit/service!
+    {:graphiql {:enabled?        true
+                :url             "http://localhost:9113/graphql"
+                :subscriptionUrl "ws://localhost:9113/graphql/subscribe"}
+     :endpoints {:graphiql  "/graphiql"
+                 :http      "/graphql"
+                 :websocket "/graphql/subscribe"}
+     ; Underlying, there is a default "middleware chain". The main responsibility
+     ; is to parse query params and json, as well as format responses.
+     ;
+     ; The resulting middleware will look like
+     ; logger -> parsing ->  logger -> health-check -> root-handler
+     :middleware {:prepend [(logger "PREPEND>")]
+                  :append  [(logger "APPEND>") (health-check "/health")]}
+     :scalars   ex.core/scalars
+     :resolvers {:query
+                 {:Mutation/addDroid ex.resolvers/add-droid
+                  :Mutation/addHuman ex.resolvers/add-human
+                  :Query/droid       ex.resolvers/droid
+                  :Query/droids      ex.resolvers/droids
+                  :Query/human       ex.resolvers/human
+                  :Query/humans      ex.resolvers/humans
+                  :Query/hero        ex.resolvers/hero
+                  :Query/heros       ex.resolvers/heros}
+                 :subscription
+                 {:Subscription/events ex.resolvers/events}}
+     :server    {:port port, #_#_:async? true}
+     :schema    {:resource "graphql/schema/star-wars.graphql"}
+     :options   {:executor (m.e/execute-pool)}}))
+

--- a/src/graphql/kit/engines/lacinia.clj
+++ b/src/graphql/kit/engines/lacinia.clj
@@ -6,6 +6,7 @@
     [com.walmartlabs.lacinia.constants :as l.constants]
     [com.walmartlabs.lacinia.executor :as l.executor]
     [com.walmartlabs.lacinia.parser :as l.parser]
+    [com.walmartlabs.lacinia.parser.schema :as l.p.schema]
     [com.walmartlabs.lacinia.schema :as l.schema]
     [com.walmartlabs.lacinia.util :as l.util]
     [graphql.kit.protos.engine :as e]))
@@ -22,6 +23,8 @@
 
 (defn compile* [{:keys [schema resolvers scalars options]}]
   (cond-> schema
+    (string? schema)
+      (l.p.schema/parse-schema)
     scalars
       (l.util/inject-scalar-transformers scalars)
     (:query resolvers)


### PR DESCRIPTION
These changes add the ability to specify a
SDL schema, rather than an EDN file.

Additionally, while testing out these changes, it seems that lacinia (or some app code) isn't properly filtering subscription results, at least w/ the SDL example.

A bug shall be logged in the graphql.kit repo for verification, and if the issue is w/ SDL and/or Lacinia, a bug shall be submitted "upstream" to that repo.