### PR TITLE
Fix Subscription Values Not Being Resolved

### DIFF
--- a/src/graphql/kit/engines/lacinia.clj
+++ b/src/graphql/kit/engines/lacinia.clj
@@ -7,9 +7,13 @@
     [com.walmartlabs.lacinia.executor :as l.executor]
     [com.walmartlabs.lacinia.parser :as l.parser]
     [com.walmartlabs.lacinia.parser.schema :as l.p.schema]
+    [com.walmartlabs.lacinia.resolve :as l.resolve]
     [com.walmartlabs.lacinia.schema :as l.schema]
     [com.walmartlabs.lacinia.util :as l.util]
-    [graphql.kit.protos.engine :as e]))
+    [graphql.kit.protos.engine :as e]
+    ; yeah, you may not like manifold, but lemme tell ya, an extra
+    ; well implemented dependency is better than a thread per query
+    [manifold.deferred :as d]))
 
 (defn as-parsed-query [schema {:keys [query operationName]}]
   (let [parsed? (map? query)]
@@ -20,6 +24,31 @@
           (l.parser/parse-query schema query operationName)
         :else
           (l.parser/parse-query schema query)))))
+
+(defn resolve-subscription-value [{:keys [ctx]} stream-fn]
+  (fn resolve-subscription-value' [value]
+    (cond
+      (nil? value)
+        ; If we get a nil value, signal to the stream to close
+        (stream-fn value :close)
+      (l.resolve/is-resolver-result? value)
+        (l.resolve/on-deliver! value resolve-subscription-value')
+      :else
+        (d/chain'
+          ; https://media.giphy.com/media/3ohuPEhzrxawUFvQn6/giphy-downsized.gif
+          (d/future
+            (l.executor/execute-query
+              (into ctx {::l.executor/resolved-value value})))
+          (fn [resolver-value]
+            (let [result (d/deferred)]
+              (l.resolve/on-deliver! resolver-value
+                (fn [resolved]
+                  ; handle nil w/ error?
+                  (d/success! result resolved)))
+              result))
+          (fn [result]
+            (stream-fn result nil))))))
+
 
 (defn compile* [{:keys [schema resolvers scalars options]}]
   (cond-> schema
@@ -61,20 +90,20 @@
       (:operationName payload)
         (assoc :operation-name (:operationName payload)))))
 
-
-; should look @ lacinia pedestal for reference impl
-; leave "empty" for now until understand the reference impl
-; better
 (defn subscribe*
   [{:keys [ctx stream-fn schema payload]
-    :or   {ctx {}}}]
+    :or   {ctx {}}
+    :as   ctx*}]
   (let [prepped (-> schema
                     (as-parsed-query payload)
                     (l.parser/prepare-with-query-variables
-                      (:variables payload)))]
+                      (:variables payload)))
+        ; a prepared query already has the schema associated with it,
+        ; and therefore, doesn't need to pe propagated to further calls
+        ctx     (assoc ctx l.constants/parsed-query-key prepped)]
     (l.executor/invoke-streamer
-      (into ctx {l.constants/parsed-query-key prepped})
-      stream-fn)))
+      ctx
+      (resolve-subscription-value (assoc ctx* :ctx ctx) stream-fn))))
 
 (defn engine! []
   (reify e/Engine

--- a/src/graphql/kit/servers/proto_impls/graphql_transport_ws.clj
+++ b/src/graphql/kit/servers/proto_impls/graphql_transport_ws.clj
@@ -58,15 +58,19 @@
 (defn pong [{:keys [conn]} {:keys [id]} _]
   (put! conn (encode {:id id, :type "ping"})))
 
-(defn subscription-streamer [{:keys [conn]} {:keys [id]} _state]
-  (fn subscription-streamer' [data]
-    (if (:errors data)
-      (put! conn (encode  {:id      id
-                           :payload (:errors data)
-                           :type    "error"}))
-      (put! conn (encode {:id      id
-                          :payload data
-                          :type    "next"})))))
+(defn subscription-streamer [{:keys [close! conn]} {:keys [id]} _state]
+  (fn subscription-streamer' [data action?]
+    (cond
+      (= :close action?)
+        (close! :invalid-message)
+      (:errors data)
+        (put! conn (encode  {:id      id
+                             :payload (:errors data)
+                             :type    "error"}))
+      :else
+        (put! conn (encode {:id      id
+                            :payload data
+                            :type    "next"})))))
 
 (defn execute-subscription
   [{:keys [engine request schema] :as ctx}


### PR DESCRIPTION
User error of lacinia. Given the example implementation in lacinia pedestal, a value received from a subscription is not automatically sent through the query parser for the result type.

This fix adds the extra step to "resolve" the value via the query parser.